### PR TITLE
Add configuration option for Nano Auth options

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,19 @@ module.exports = function(config) {
 
   var server, db;
 
-  if (config.couch) {
+  if (config.couch && !config.couch_username ) {
     db = nano(config.couch);
+  } else if (config.couch_username && config.couch_password) {
+    db = nano({
+      url: config.users,
+      request_defaults: {
+        auth: {
+          username: config.couch_username,
+          password: config.couch_password
+        },
+        strictSSL: false
+      }
+    });
   } else {
     server = nano(config.url);
     db = config.database_parameter_name || 'COUCH_DB';


### PR DESCRIPTION
### Issue

Currently if this module is used with a couchDB that requires an authorized user to make requests it will fail to complete the request.
### Solution

Added a hook for nano to be configured with a couchDB Admin for authentication if the information is passed in via the config variables 'couch_username' and 'couch_password', otherwise nano will be configured as normal.
