### PR TITLE
Db auth

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,19 +8,14 @@ module.exports = function(config) {
 
   var server, db;
 
-  if (config.couch && !config.couch_username ) {
+  if (config.couch && !config.request_defaults ) {
     db = nano(config.couch);
-  } else if (config.couch_username && config.couch_password) {
-    db = nano({
-      url: config.users,
-      request_defaults: {
-        auth: {
-          username: config.couch_username,
-          password: config.couch_password
-        },
-        strictSSL: false
-      }
+  } else if (config.request_defaults) {
+    server = nano({
+      url: config.url,
+      request_defaults: config.request_defaults
     });
+    db = config.database_parameter_name || 'COUCH_DB';
   } else {
     server = nano(config.url);
     db = config.database_parameter_name || 'COUCH_DB';
@@ -67,7 +62,7 @@ module.exports = function(config) {
       if (err) { return res.send(500, err); }
       fs.readFile(req.files.uploadFile.path, function(err, data) {
         if (err) { return res.send(500, err); }
-        getDb(req).attachment.insert(body.id, 'file', data, meta.type, 
+        getDb(req).attachment.insert(body.id, 'file', data, meta.type,
           { rev: body.rev }, function(e,b) {
             if (e) { return res.send(500, e); }
             res.send(b);
@@ -83,6 +78,6 @@ module.exports = function(config) {
       getDb(req).destroy(req.params.name, body._rev).pipe(res);
     });
   });
-  
+
   return app;
 };


### PR DESCRIPTION
### Issue

Currently if this module is used with a couchDB that requires an authorized user to make requests it will fail to complete the request.
### Solution

Added a hook for nano to be configured with a couchDB Admin for authentication if the information is passed in via  config.request_defaults, otherwise nano will be configured as normal.
