### PR TITLE
Include Content-Type header w/ doc.mime

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,10 @@ module.exports = function(config) {
       .get(req.params.name)
       .catch(() => ({ name: 'file not found' }))
 
-    res.set('Content-Disposition', condis(doc.name, { type: disposition }))
+    res.set({
+      'Content-Disposition': condis(doc.name, { type: disposition }),
+      'Content-Type': doc.mime
+    })
     
     if (path(['_attachments', 'file'], doc)) {
       const s = db.attachment.getAsStream(req.params.name, 'file')


### PR DESCRIPTION
When attempting to get a file, we need to include the content type with the associated `doc.mime`. I noticed that this header was previously being set in versions prior to `1.0.0`, was there any particular reason it was removed?